### PR TITLE
WEB-517: Set up auto-deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+name: deploy
+on:
+  push:
+    branches:
+      - master
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          version: '290.0.1'
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+      - name: Use gcloud CLI
+        run: gcloud info
+      - name: Install frontend packages and build frontend
+        run: cd react && npm install && npm run build
+      - name: Copy project files
+        run: gcloud compute scp --recurse react/build/static root@proton-sign-deployed:/var/www/html/ --zone "us-west2-a" && gcloud compute scp react/build/index.html root@proton-sign-deployed:/var/www/html/ --zone "us-west2-a" && gcloud compute scp --recurse php root@proton-sign-deployed:/var/www/html/psignapi --zone "us-west2-a"


### PR DESCRIPTION
Tested successfully on push to branch!

Cleaned up commits and changed

```
on: push
```

to:

```
on:
  push:
    branches:
      - master
```

Working deployment workflow logs: https://github.com/ProtonProtocol/proton-sign/actions/runs/464211476

---

**Note:**
Workflow needs to be connected to [Compute Engine default service account](https://console.cloud.google.com/identity/serviceaccounts/details/109890549150220008245?authuser=2&project=proton-wallet&supportedpurview=project) (email: 244127841065-compute@developer.gserviceaccount.com).