### PR TITLE
WEB-573: Mobile users are not seeing a confirmation scene when successfully signing a document

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -2,7 +2,7 @@
   "name": "protonsign",
   "version": "0.1.0",
   "private": true,
-  "proxy": "http://35.236.54.120/",
+  "proxy": "https://sign.protonchain.com/",
   "dependencies": {
     "@protonprotocol/proton-web-sdk": "2.6.0",
     "@testing-library/jest-dom": "^5.11.5",

--- a/react/src/pages/Sign/Container.jsx
+++ b/react/src/pages/Sign/Container.jsx
@@ -102,10 +102,7 @@ class SignContainer extends React.Component {
               }
 
               if (isResult) {
-                history.push({
-                  pathname: '/signaturecompleted',
-                  search: window.location.search,
-                });
+                history.push('/signaturecompleted');
               } else {
                 console.warn(data);
               }


### PR DESCRIPTION
Tested locally with my mobile device running on local host and then prepending the email link with my localhost port instead of `sign.protonchain.com`.

I think mobile safari had an issue with `window.location.search` in the snippet below. Simplifying the `history.push` call fixed the mobile redirection.

```js
history.push({
    pathname: '/signaturecompleted',	
    search: window.location.search,	
});
```